### PR TITLE
[wgo-321]: error check for file path and dest path

### DIFF
--- a/windows/RNFS/RNFSManager.cs
+++ b/windows/RNFS/RNFSManager.cs
@@ -278,8 +278,25 @@ namespace RNFS
         [ReactMethod]
         public async void copyFile(string filepath, string destPath, IReactPromise<JSValue> promise)
         {
-            await Task.Run(() => File.Copy(filepath, destPath)).ConfigureAwait(true);
-            promise.Resolve(true);
+            try
+            {
+                if (!(File.Exists(filepath)))
+                {
+                    RejectFileNotFound(promise, filepath);
+                    return;
+                }
+                if (!(Directory.Exists(destPath)))
+                {
+                    RejectFileNotFound(promise, destPath);
+                    return;
+                }
+                await Task.Run(() => File.Copy(filepath, destPath)).ConfigureAwait(true);
+                promise.Resolve(true);
+            }
+            catch (Exception ex)
+            {
+                Reject(promise, filepath, ex);
+            }
         }
 
         [ReactMethod]


### PR DESCRIPTION
[WGO-321](https://servicemax.atlassian.net/browse/WGO-321)

This PR reject the promise with 'no such file or directory' when file path or dest path doesn't exist.

@svmx-amresh-kumar @thiruppathi-svmx @rahman2835 @sakthivel-servicemax 