### PR TITLE
[WGO-963]: config sync fix

### DIFF
--- a/windows/RNFS/RNFSManager.cs
+++ b/windows/RNFS/RNFSManager.cs
@@ -285,11 +285,6 @@ namespace RNFS
                     RejectFileNotFound(promise, filepath);
                     return;
                 }
-                if (!(Directory.Exists(destPath)))
-                {
-                    RejectFileNotFound(promise, destPath);
-                    return;
-                }
                 await Task.Run(() => File.Copy(filepath, destPath)).ConfigureAwait(true);
                 promise.Resolve(true);
             }


### PR DESCRIPTION
[WGO-963](https://servicemax.atlassian.net/browse/WGO-963)
[WGO-965](https://servicemax.atlassian.net/browse/WGO-965)

This condition check is creating issue for config sync and zip file creation for share error report. 

I have added two condition check (for filepath and destpath)in my previous PR but this condition check(directory for destpath) wasn't required for my fix.
Ref: https://github.com/ServiceMax-Engineering/react-native-fs/pull/2

@svmx-amresh-kumar @sakthivel-servicemax @rahman2835 @thiruppathi-svmx 